### PR TITLE
Fix app.py name to streamlit_app.py in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 This project demonstrates the [Udacity self-driving-car dataset](https://github.com/udacity/self-driving-car) and [YOLO object detection](https://pjreddie.com/darknet/yolo) into an interactive [Streamlit](https://streamlit.io) app.
 
-The complete demo is [implemented in less than 300 lines of Python](https://github.com/streamlit/demo-self-driving/blob/master/app.py) and illustrates all the major building blocks of Streamlit.
+The complete demo is [implemented in less than 300 lines of Python](https://github.com/streamlit/demo-self-driving/blob/master/streamlit_app.py) and illustrates all the major building blocks of Streamlit.
 
 ![Making-of Animation](https://raw.githubusercontent.com/streamlit/demo-self-driving/master/av_final_optimized.gif "Making-of Animation")
 
 ## How to run this demo
 ```
 pip install --upgrade streamlit opencv-python
-streamlit run https://raw.githubusercontent.com/streamlit/demo-self-driving/master/app.py
+streamlit run https://raw.githubusercontent.com/streamlit/demo-self-driving/master/streamlit_app.py
 ```
 
 ### Questions? Comments?


### PR DESCRIPTION
A recent change [#13] changed the name of `app.py` to `streamlit_app.y`. Changing readme to reflect that.