### PR TITLE
Fix filename in st.code as it has changed

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -39,7 +39,7 @@ def main():
         st.sidebar.success('To continue select "Run the app".')
     elif app_mode == "Show the source code":
         readme_text.empty()
-        st.code(get_file_content_as_string("app.py"))
+        st.code(get_file_content_as_string("streamlit_app.py"))
     elif app_mode == "Run the app":
         readme_text.empty()
         run_the_app()


### PR DESCRIPTION
The app name has changed from app.py to streamlit_app.py but the "Show the source code" option still attempts to display the code from app.py and runs into an error. This PR updates the filename for which the code should be shown,