### PR TITLE
Avoid warnings caused by deprecated streamlit usages

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -196,7 +196,7 @@ def draw_image_with_boxes(image, boxes, header, description):
     st.image(image_with_boxes.astype(np.uint8), use_column_width=True)
 
 # Download a single file and make its content available as a string.
-@st.experimental_singleton(show_spinner=False)
+@st.cache_resource (show_spinner=False)
 def get_file_content_as_string(path):
     url = 'https://raw.githubusercontent.com/streamlit/demo-self-driving/master/' + path
     response = urllib.request.urlopen(url)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -84,14 +84,14 @@ def download_file(file_path):
 
 # This is the main app app itself, which appears when the user selects "Run the app".
 def run_the_app():
-    # To make Streamlit fast, st.cache allows us to reuse computation across runs.
+    # To make Streamlit fast, st.cache_data allows us to reuse computation across runs.
     # In this common pattern, we download data from an endpoint only once.
-    @st.experimental_memo
+    @st.cache_data
     def load_metadata(url):
         return pd.read_csv(url)
 
     # This function uses some Pandas magic to summarize the metadata Dataframe.
-    @st.experimental_memo
+    @st.cache_data
     def create_summary(metadata):
         one_hot_encoded = pd.get_dummies(metadata[["frame", "label"]], columns=["label"])
         summary = one_hot_encoded.groupby(["frame"]).sum().rename(columns={
@@ -164,7 +164,7 @@ def frame_selector_ui(summary):
     return selected_frame_index, selected_frame
 
 # Select frames based on the selection in the sidebar
-@st.cache(hash_funcs={np.ufunc: str})
+@st.cache_data(hash_funcs={np.ufunc: str})
 def get_selected_frames(summary, label, min_elts, max_elts):
     return summary[np.logical_and(summary[label] >= min_elts, summary[label] <= max_elts)].index
 
@@ -202,9 +202,9 @@ def get_file_content_as_string(path):
     response = urllib.request.urlopen(url)
     return response.read().decode("utf-8")
 
-# This function loads an image from Streamlit public repo on S3. We use st.cache on this
+# This function loads an image from Streamlit public repo on S3. We use st.cache_data on this
 # function as well, so we can reuse the images across runs.
-@st.experimental_memo(show_spinner=False)
+@st.cache_data(show_spinner=False)
 def load_image(url):
     with urllib.request.urlopen(url) as response:
         image = np.asarray(bytearray(response.read()), dtype="uint8")
@@ -215,7 +215,8 @@ def load_image(url):
 # Run the YOLO model to detect objects.
 def yolo_v3(image, confidence_threshold, overlap_threshold):
     # Load the network. Because this is cached it will only happen once.
-    @st.cache(allow_output_mutation=True)
+    # For unserializable object, we use st.cache_resource() to migrate from st.cache().
+    @st.cache_resource()
     def load_network(config_path, weights_path):
         net = cv2.dnn.readNetFromDarknet(config_path, weights_path)
         output_layer_names = net.getLayerNames()


### PR DESCRIPTION
I saw some ugly warnings caused by deprecated usages in streamlit.

I replace them and test the demo works.

Now we have a clean demo!

<img width="1280" alt="7040ab659450ff571b549c82a8368f7" src="https://github.com/streamlit/demo-self-driving/assets/72114686/5bc68056-5687-49bc-8762-0c7cde81a760">
